### PR TITLE
Add `nowplaying` command.

### DIFF
--- a/java-src/cljukebox/AudioTrackScheduler.java
+++ b/java-src/cljukebox/AudioTrackScheduler.java
@@ -24,6 +24,10 @@ public final class AudioTrackScheduler extends AudioEventAdapter {
     return queue;
   }
 
+  public AudioTrack nowPlaying() {
+    return player.getPlayingTrack();
+  }
+
   public boolean play(final AudioTrack track) {
     return play(track, false);
   }

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/tools.logging "1.2.3"]
                  [com.fasterxml.jackson.core/jackson-core "2.12.5"]
                  [com.discord4j/discord4j-core "3.2.0"]
                  [com.discord4j/discord4j-rest "3.2.0"]

--- a/src/cljukebox/core.clj
+++ b/src/cljukebox/core.clj
@@ -1,5 +1,6 @@
 (ns cljukebox.core
   (:require [clojure.string :as string]
+            [clojure.tools.logging :as log]
             [cljukebox.util :as util]
             [cljukebox.handlers :as handlers])
   (:import [discord4j.core DiscordClient GatewayDiscordClient]
@@ -80,6 +81,7 @@
          (-> application-service
              (.createGlobalApplicationCommand application-id command-request)
              (.subscribe))))
+         (log/info (format "Slash commanded added for %s" name))))
      handlers/handlers)))
 
 (defn handle-client [^GatewayDiscordClient client]

--- a/src/cljukebox/handlers.clj
+++ b/src/cljukebox/handlers.clj
@@ -8,7 +8,8 @@
              [leave :as leave]
              [skip :as skip]
              [loop :as loop]
-             [clear :as clear]]))
+             [clear :as clear]
+             [nowplaying :as np]]))
 
 (def base-handlers
   {"prefix" prefix/handler-data
@@ -17,7 +18,8 @@
    "leave" leave/handler-data
    "skip" skip/handler-data
    "loop" loop/handler-data
-   "clear" clear/handler-data})
+   "clear" clear/handler-data
+   "nowplaying" np/handler-data})
 
 (defn help-handler
   ([{:keys [message-channel content] :as data}]

--- a/src/cljukebox/handlers/nowplaying.clj
+++ b/src/cljukebox/handlers/nowplaying.clj
@@ -1,0 +1,31 @@
+(ns cljukebox.handlers.nowplaying
+  (:require [cljukebox.player :as player]
+            [cljukebox.util :as util]))
+
+(defn mk-embed [current-track]
+  (let [{:keys [title author length uri identifier] :as track-info} (player/track->map current-track)]
+    {:title title
+     :url uri
+     :fields [{:name "Author"
+               :value author
+               :inline true}
+              {:name "Length"
+               :value length
+               :inline true}
+              {:name "Audio ID"
+               :value identifier
+               :inline true}]}))
+
+(defn audio-queue
+  ([data]
+   (audio-queue data nil))
+  ([{:keys [message-channel guild-id] :as data} _opts]
+   (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)]
+     (if-let [current-track (.nowPlaying scheduler)]
+       (util/send-embed message-channel (mk-embed current-track))
+       (util/send-message message-channel "No song is currently playing on the bot.")))))
+
+(def handler-data
+  {:doc "Outputs the currently playing song in the queue"
+   :usage-str "nowplaying"
+   :handler-fn audio-queue})


### PR DESCRIPTION
Adds the `nowplaying` command to the bot's list of handlers. 

Outputs an embed with info about the currently track on the player:
- Title of the track (along with a URL to the track)
- Author
- Length
- Track identifier

**Example:**
![image](https://user-images.githubusercontent.com/22668517/147170385-d86cdae8-4ace-48e5-bea3-50e70bcf3b14.png)
 