### PR TITLE
Queue improvements

### DIFF
--- a/src/cljukebox/handlers/queue.clj
+++ b/src/cljukebox/handlers/queue.clj
@@ -1,6 +1,13 @@
 (ns cljukebox.handlers.queue
   (:require [cljukebox.player :as player]
-            [cljukebox.util :as util]))
+            [cljukebox.util :as util])
+  (:import java.lang.NumberFormatException))
+
+(defn calculate-queue-length [track-queue]
+  (->> track-queue
+       (map (fn [track] (-> track .getInfo .length)))
+       (reduce +)
+       util/millis->time-str))
 
 (defn create-track-field [idx track]
   (let [{:keys [title author length] :as track-info} (player/track->map track)]
@@ -8,16 +15,36 @@
      :value (format "**Author**: %s | **Length**: %s" author length)}))
 
 (defn audio-queue
-  ([data]
-   (audio-queue data nil))
-  ([{:keys [message-channel guild-id] :as data} _opts]
-   (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)
-         track-queue (.queue scheduler)]
-     (util/send-embed message-channel {:title "Bot Queue"
-                                       :description "Currently queued songs on the bot:"
-                                       :fields (map-indexed create-track-field track-queue)}))))
+  ([{:keys [content] :as data}]
+   (let [page-number (util/get-arguments content)]
+     (audio-queue data {:page-number page-number})))
+  ([{:keys [message-channel guild-id] :as data} {:keys [page-number] :as opts}]
+   (try
+     (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)
+           track-queue (.queue scheduler)
+           page-number (or (some-> page-number Long/parseLong) 1)
+           track-offset (* (- page-number 1) 20)
+           track-queue-page (take 20 (drop track-offset track-queue))
+           page-indexes (range (+ track-offset 1)
+                               (+ track-offset (count track-queue-page) 1))]
+       (util/send-embed message-channel {:title "Bot Queue"
+                                         :fields (concat [{:name "Total Tracks"
+                                                           :value (str (count track-queue))
+                                                           :inline true}
+                                                          {:name "Queue Length"
+                                                           :value (calculate-queue-length track-queue)
+                                                           :inline true}
+                                                          {:name "Page"
+                                                           :value (str page-number)
+                                                           :inline true}]
+                                                         (map create-track-field page-indexes track-queue-page))}))
+     (catch NumberFormatException e
+       (util/send-message message-channel "Invalid page number provided - should be an integer, e.g `queue 2`")))))
 
 (def handler-data
   {:doc "Outputs the current player queue for the server"
    :usage-str "queue"
+   :args [{:name "page-number"
+           :doc "Which page of the queue to display (each page contains 20 results)"
+           :required? false}]
    :handler-fn audio-queue})

--- a/src/cljukebox/util.clj
+++ b/src/cljukebox/util.clj
@@ -97,7 +97,7 @@
 (defn millis->time-str [millis]
   (let [minutes (int (/ (/ millis 1000) 60))
         seconds (int (mod (/ millis 1000) 60))]
-    (format "%d:%d" minutes seconds)))
+    (format "%d:%02d" minutes seconds)))
 
 (defn get-arguments [content-with-command]
   (let [args (rest (string/split content-with-command #" "))]


### PR DESCRIPTION
Fixes #9:

- Improves formatting of time strings - will display `1:03` rather than `1:3`
- Adds paging of results into the queue - no longer breaks when queue is sufficiently large.
- Adds some extra information to the queue command.