### PR TITLE
Only create guild audio manager on voice connect.

### DIFF
--- a/src/cljukebox/handlers/clear.clj
+++ b/src/cljukebox/handlers/clear.clj
@@ -2,13 +2,17 @@
   (:require [cljukebox.player :as player]
             [cljukebox.util :as util]))
 
+(defn clear-scheduler [{:keys [message-channel]} {:keys [scheduler]}]
+  (.clear scheduler)
+  (util/send-message message-channel ":wastebasket: **Bot queue cleared!**"))
+
 (defn clear-bot
   ([data]
    (clear-bot data nil))
   ([{:keys [message-channel guild-id] :as data} _opts]
-   (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)]
-     (.clear scheduler)
-     (util/send-message message-channel ":wastebasket: **Bot queue cleared!**"))))
+   (if-let [guild-manager (player/get-guild-audio-manager guild-id)]
+     (clear-scheduler data guild-manager)
+     (util/missing-audio-manager-message message-channel))))
 
 (def handler-data
   {:doc "Will skip the currently playing track and remove all songs from the queue."

--- a/src/cljukebox/handlers/loop.clj
+++ b/src/cljukebox/handlers/loop.clj
@@ -4,16 +4,20 @@
 
 (def !loop (atom false))
 
+(defn loop-scheduler [{:keys [message-channel]} {:keys [scheduler]}]
+  (let [should-loop (swap! !loop not)]
+    (.setLoop scheduler should-loop)
+    (if should-loop
+      (util/send-message message-channel ":repeat: **Loop enabled!**")
+      (util/send-message message-channel ":repeat: **Loop disabled!**"))))
+
 (defn loop-audio
   ([data]
    (loop-audio data nil))
   ([{:keys [message-channel guild-id] :as data} _opts]
-   (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)
-         should-loop (swap! !loop not)]
-     (.setLoop scheduler should-loop)
-     (if should-loop
-       (util/send-message message-channel ":repeat: **Loop enabled!**")
-       (util/send-message message-channel ":repeat: **Loop disabled!**")))))
+   (if-let [guild-manager (player/get-guild-audio-manager guild-id)]
+     (loop-scheduler data guild-manager)
+     (util/missing-audio-manager-message message-channel))))
 
 (def handler-data
   {:doc "Will loop all songs that play on the bot - these will play until skipped"

--- a/src/cljukebox/handlers/nowplaying.clj
+++ b/src/cljukebox/handlers/nowplaying.clj
@@ -16,16 +16,20 @@
                :value identifier
                :inline true}]}))
 
-(defn audio-queue
+(defn output-now-playing [{:keys [message-channel]} {:keys [scheduler]}]
+  (if-let [current-track (.nowPlaying scheduler)]
+    (util/send-embed message-channel (mk-embed current-track))
+    (util/send-message message-channel "No song is currently playing on the bot.")))
+
+(defn now-playing
   ([data]
-   (audio-queue data nil))
+   (now-playing data nil))
   ([{:keys [message-channel guild-id] :as data} _opts]
-   (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)]
-     (if-let [current-track (.nowPlaying scheduler)]
-       (util/send-embed message-channel (mk-embed current-track))
-       (util/send-message message-channel "No song is currently playing on the bot.")))))
+   (if-let [guild-manager (player/get-guild-audio-manager guild-id)]
+     (output-now-playing data guild-manager)
+     (util/missing-audio-manager-message message-channel))))
 
 (def handler-data
   {:doc "Outputs the currently playing song in the queue"
    :usage-str "nowplaying"
-   :handler-fn audio-queue})
+   :handler-fn now-playing})

--- a/src/cljukebox/handlers/play.clj
+++ b/src/cljukebox/handlers/play.clj
@@ -10,8 +10,8 @@
   ([{:keys [voice-channel message-channel guild-id] :as data} {:keys [url] :as opts}]
    (if-not voice-channel
      (util/send-message message-channel "You're not in a voice channel - join one to queue songs on the bot.")
-     (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)]
-       (player/connect-to-voice guild-manager voice-channel)
+     (let [_ (player/connect-to-voice data)
+           {:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)]
        (.loadItemOrdered player/player-manager
                          guild-manager
                          url

--- a/src/cljukebox/handlers/queue.clj
+++ b/src/cljukebox/handlers/queue.clj
@@ -14,32 +14,36 @@
     {:name (format "%d: %s" idx title)
      :value (format "**Author**: %s | **Length**: %s" author length)}))
 
+(defn output-audio-queue [{:keys [message-channel]} {:keys [page-number]} {:keys [scheduler]}]
+  (try
+    (let [track-queue (.queue scheduler)
+          page-number (or (some-> page-number Long/parseLong) 1)
+          track-offset (* (- page-number 1) 20)
+          track-queue-page (take 20 (drop track-offset track-queue))
+          page-indexes (range (+ track-offset 1)
+                              (+ track-offset (count track-queue-page) 1))]
+      (util/send-embed message-channel {:title "Bot Queue"
+                                        :fields (concat [{:name "Total Tracks"
+                                                          :value (str (count track-queue))
+                                                          :inline true}
+                                                         {:name "Queue Length"
+                                                          :value (calculate-queue-length track-queue)
+                                                          :inline true}
+                                                         {:name "Page"
+                                                          :value (str page-number)
+                                                          :inline true}]
+                                                        (map create-track-field page-indexes track-queue-page))}))
+    (catch NumberFormatException e
+      (util/send-message message-channel "Invalid page number provided - should be an integer, e.g `queue 2`"))))
+
 (defn audio-queue
   ([{:keys [content] :as data}]
    (let [page-number (util/get-arguments content)]
      (audio-queue data {:page-number page-number})))
-  ([{:keys [message-channel guild-id] :as data} {:keys [page-number] :as opts}]
-   (try
-     (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)
-           track-queue (.queue scheduler)
-           page-number (or (some-> page-number Long/parseLong) 1)
-           track-offset (* (- page-number 1) 20)
-           track-queue-page (take 20 (drop track-offset track-queue))
-           page-indexes (range (+ track-offset 1)
-                               (+ track-offset (count track-queue-page) 1))]
-       (util/send-embed message-channel {:title "Bot Queue"
-                                         :fields (concat [{:name "Total Tracks"
-                                                           :value (str (count track-queue))
-                                                           :inline true}
-                                                          {:name "Queue Length"
-                                                           :value (calculate-queue-length track-queue)
-                                                           :inline true}
-                                                          {:name "Page"
-                                                           :value (str page-number)
-                                                           :inline true}]
-                                                         (map create-track-field page-indexes track-queue-page))}))
-     (catch NumberFormatException e
-       (util/send-message message-channel "Invalid page number provided - should be an integer, e.g `queue 2`")))))
+  ([{:keys [message-channel guild-id] :as data} opts]
+   (if-let [guild-manager (player/get-guild-audio-manager guild-id)]
+     (output-audio-queue data opts guild-manager)
+     (util/missing-audio-manager-message message-channel))))
 
 (def handler-data
   {:doc "Outputs the current player queue for the server"

--- a/src/cljukebox/handlers/shuffle.clj
+++ b/src/cljukebox/handlers/shuffle.clj
@@ -2,13 +2,17 @@
   (:require [cljukebox.player :as player]
             [cljukebox.util :as util]))
 
+(defn shuffle-scheduler [{:keys [message-channel]} {:keys [scheduler]}]
+  (.shuffle scheduler)
+  (util/send-message message-channel ":twisted_rightwards_arrows: **Bot queue shuffled!**"))
+
 (defn shuffle-playlist
   ([data]
    (shuffle-playlist data nil))
   ([{:keys [message-channel guild-id] :as data} _opts]
-   (let [{:keys [scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)]
-     (.shuffle scheduler)
-     (util/send-message message-channel ":twisted_rightwards_arrows: **Bot queue shuffled!**"))))
+   (if-let [guild-manager (player/get-guild-audio-manager guild-id)]
+     (shuffle-scheduler data guild-manager)
+     (util/missing-audio-manager-message message-channel))))
 
 (def handler-data
   {:doc "Shuffles the contents of the playlist"

--- a/src/cljukebox/handlers/skip.clj
+++ b/src/cljukebox/handlers/skip.clj
@@ -2,17 +2,21 @@
   (:require [cljukebox.player :as player]
             [cljukebox.util :as util]))
 
-(defn skip-audio
-  ([data]
-   (skip-audio data nil))
-  ([{:keys [message-channel guild-id] :as data} _opts]
-   (let [{:keys [player scheduler] :as guild-manager} (player/get-guild-audio-manager guild-id)
-         current-song (.getPlayingTrack player)]
+(defn skip-track [{:keys [message-channel]} {:keys [player scheduler]}]
+  (let [current-song (.getPlayingTrack player)]
      (if current-song
        (let [{:keys [title]} (player/track->map current-song)]
          (.skip scheduler)
          (util/send-message message-channel (format "Track: `%s` has been skipped" title)))
-       (util/send-message message-channel "No song is currently playing on the bot - nothing skipped")))))
+       (util/send-message message-channel "No song is currently playing on the bot - nothing skipped"))))
+
+(defn skip-audio
+  ([data]
+   (skip-audio data nil))
+  ([{:keys [message-channel guild-id] :as data} _opts]
+   (if-let [guild-manager (player/get-guild-audio-manager guild-id)]
+     (skip-track data guild-manager)
+     (util/missing-audio-manager-message message-channel))))
 
 (def handler-data
   {:doc "Skips the currently playing song, playing the next song in the queue (if any is present)"

--- a/src/cljukebox/player.clj
+++ b/src/cljukebox/player.clj
@@ -60,9 +60,7 @@
     guild-audio-manager))
 
 (defn get-guild-audio-manager [guild-id]
-  (if-let [current-guild-audio-manager (get @!guild-audio-managers guild-id)]
-    current-guild-audio-manager
-    (mk-guild-audio-manager guild-id)))
+  (get @!guild-audio-managers guild-id))
 
 (defn handle-guild-disconnect [guild-id]
   (swap! !guild-audio-managers dissoc guild-id)
@@ -71,9 +69,10 @@
 (defn get-current-connection [guild-id]
   (get @!voice-connections guild-id))
 
-(defn connect-to-voice [{:keys [guild-id provider] :as guild-manager} voice-channel]
+(defn connect-to-voice [{:keys [voice-channel guild-id]}]
   (when-not (get @!voice-connections guild-id)
-    (let [voice-connection (-> (.join voice-channel (util/as-consumer (fn [spec] (.setProvider spec provider))))
+    (let [{:keys [provider]} (mk-guild-audio-manager guild-id)
+          voice-connection (-> (.join voice-channel (util/as-consumer (fn [spec] (.setProvider spec provider))))
                                .block)]
       (log/info (format "Connecting bot to voice-channel in guild %s" guild-id))
       (swap! !voice-connections assoc guild-id voice-connection))))

--- a/src/cljukebox/util.clj
+++ b/src/cljukebox/util.clj
@@ -103,3 +103,6 @@
   (let [args (rest (string/split content-with-command #" "))]
     (cond-> args
       (< (count args) 2) first)))
+
+(defn missing-audio-manager-message [message-channel]
+  (send-message message-channel "**Bot must be connected to voice!**"))


### PR DESCRIPTION
Ensures that guild audio managers and voice connections are coupled - and new audio managers cannot be created seperate of voice connections.